### PR TITLE
Fix seen causa

### DIFF
--- a/Challenge/models.py
+++ b/Challenge/models.py
@@ -253,10 +253,7 @@ class Challenge(models.Model):
     def get_questions(course):
         result = Challenge.objects.filter(
             course=course,
-            comments__parent=None,
-            comments__seen=False,
-        ).exclude(
-            comments__visibility=Comment.PRIVATE
+            comments__seen=False
         ).distinct()
 
         return result

--- a/Comments/models.py
+++ b/Comments/models.py
@@ -129,6 +129,14 @@ class Comment(models.Model):
         tags = [tag.lower() for tag in tags]
         self.tags.add(*tags)
 
+    def thread_seen(self):
+        if not self.seen:
+            return False
+        for child in self.children.all():
+            if not child.seen:
+                return False
+        return True
+
     @staticmethod
     def query_tagged(tags):
         return Comment.objects.filter(tags__name__in=tags)

--- a/Comments/static/Comments/comments.js
+++ b/Comments/static/Comments/comments.js
@@ -431,6 +431,11 @@ var COMMENTS = (function (my, $, purgsLoadFilter) {
             var $replyTextarea = $('#replyTextarea');
             var text = $replyTextarea.val();
 
+            var $seen_button = $button_post_reply.closest('div.comment_with_responses').find('.mark_seen_link');
+            if (typeof $seen_button !== 'undefined') {
+                $seen_button.click();
+            }
+
             $replyForm.after($newComment);
             $newComment.find(".comment_text").text(text);
             $replyForm.hide();

--- a/Comments/static/Comments/simple_functions.js
+++ b/Comments/static/Comments/simple_functions.js
@@ -136,7 +136,7 @@ var COMMENTS = (function (my, $) {
     };
 
     my.registerSeenLinksForCommentList = function($comment_list) {
-        $comment_list.find('.comment_seen').click(function(event) {
+        $comment_list.find('.mark_seen_link').click(function(event) {
             var $this = $(this);
             markSeen($this, event);
         });
@@ -163,7 +163,7 @@ var COMMENTS = (function (my, $) {
             my.post(url, data);
 
             $this.off();
-            $this.toggleClass('comment_unseen comment_seen');
+            $this.removeClass('mark_seen_link').addClass('seen_link');
             $this.text('seen');
 
             return false;

--- a/Comments/templates/Comments/comment_list_page.html
+++ b/Comments/templates/Comments/comment_list_page.html
@@ -11,7 +11,8 @@
         </div>
 
         {% if requester.is_staff %}
-            <a href='#' class="comment_seen" title="What has been seen, cannot be unseen!">
+            <a href='#' class="{% if comment.thread_seen %} seen_link {% else %} mark_seen_link {% endif %}"
+               title="What has been seen, cannot be unseen!">
                 {% if comment.thread_seen %} seen {% else %} Mark seen {% endif %}
             </a>
         {% endif %}

--- a/Comments/templates/Comments/comment_list_page.html
+++ b/Comments/templates/Comments/comment_list_page.html
@@ -12,7 +12,7 @@
 
         {% if requester.is_staff %}
             <a href='#' class="comment_seen" title="What has been seen, cannot be unseen!">
-                {% if comment.seen %} seen {% else %} Mark seen {% endif %}
+                {% if comment.thread_seen %} seen {% else %} Mark seen {% endif %}
             </a>
         {% endif %}
     </div>

--- a/Comments/tests.py
+++ b/Comments/tests.py
@@ -2,11 +2,11 @@ from django.test import TestCase
 from Comments.models import Comment, CommentReferenceObject
 from AuroraUser.models import AuroraUser
 from django.utils import timezone
-from django.template import Context, Template
-from django import template
+import Comments.views as views
 
 
-def create_comment(text, author, reference_object, parent=None, days=0, minutes=0, seconds=0):
+def create_comment(text, author, reference_object, parent=None, visibility=Comment.PUBLIC,
+                   days=0, minutes=0, seconds=0):
     """
     creates and returns a new Comment Model object that is not being persisted
     with text by author attached to reference_object
@@ -27,8 +27,40 @@ def create_comment(text, author, reference_object, parent=None, days=0, minutes=
     delta = timezone.timedelta(days=-days, seconds=-(minutes*60) + seconds)
     post_date = timezone.now() + delta
     comment = Comment.objects.create(text=text, author=author, parent=parent, post_date=post_date,
-                                     content_object=reference_object)
+                                     content_object=reference_object, visibility=visibility)
     return comment
+
+
+class TestSetup():
+    def __init__(self, users=5, comment_no=5, ref_object=None):
+        if ref_object is None:
+            self.ref_object = CommentReferenceObject.objects.create
+        else:
+            self.ref_object = ref_object
+
+        self.user_generator = dummy_user_generator()
+        self.comment_generator = self.create_comment_generator()
+        self.comments = []
+        self.users = []
+        self.texts = ['apfel', 'baum', 'schlauch']
+        self.current_ref_object = self.ref_object
+
+        for _ in range(users):
+            self.users.append(next(self.user_generator))
+
+        for _ in range(comment_no):
+            next(self.comment_generator)
+
+    def create_comment_generator(self):
+        user_index = 0
+        text_index = 0
+
+        while True:
+            comment = create_comment(self.texts[text_index], self.users[user_index], self.current_ref_object)
+            self.comments.append(comment)
+            user_index = (user_index + 1) % len(self.users)
+            text_index = (text_index + 1) % len(self.texts)
+            yield comment
 
 
 def dummy_user_generator():
@@ -36,27 +68,37 @@ def dummy_user_generator():
     while True:
         i += 1
         n = str(i)
-        user = AuroraUser(username='du'+n, first_name='first'+n,
-                             last_name='last'+n, email='du'+n+'@foo.bar')
+        user = AuroraUser.objects.create(username='du'+n, first_name='first'+n,
+                                         last_name='last'+n, email='du'+n+'@foo.bar')
         user.nickname = 'duni' + n
         user.password = 'dupa' + n
 
         yield user
 
 
-def dummy_comment_generator():
-    # TODO implement
-    pass
+class ViewMethodTests(TestCase):
+    def test_mark_thread_seen_parent(self):
+        setup = TestSetup(comment_no=1)
+        parent = setup.comments[0]
+        parent.seen = False
+        parent.save()
 
-# class CommentMethodTests(TestCase):
-#     user_generator = dummy_user_generator()
-#
-#     def test_post_date_relative_days_ago(self):
-#         u = self.user_generator.next()
-#         u.save()
-#         c = create_comment("helo und so", u, days=2, minutes=8)
-#         c.save()
-#         self.assertEqual(c.post_date_relative, "2 days ago")
+        views.mark_thread_seen(parent)
+        self.assertTrue(parent.seen)
+
+    def test_mark_thread_seen_child(self):
+        setup = TestSetup()
+        parent = setup.comments[0]
+        parent.seen = False
+        parent.save()
+        for comment in setup.comments[1:]:
+            comment.parent = parent
+            comment.seen = False
+            comment.save()
+
+        views.mark_thread_seen(setup.comments[3])
+        for comment in setup.comments:
+            self.assertTrue(comment.seen)
 
 
 class ModelMethodTests(TestCase):

--- a/Comments/tests.py
+++ b/Comments/tests.py
@@ -76,31 +76,6 @@ def dummy_user_generator():
         yield user
 
 
-class ViewMethodTests(TestCase):
-    def test_mark_thread_seen_parent(self):
-        setup = TestSetup(comment_no=1)
-        parent = setup.comments[0]
-        parent.seen = False
-        parent.save()
-
-        views.mark_thread_seen(parent)
-        self.assertTrue(parent.seen)
-
-    def test_mark_thread_seen_child(self):
-        setup = TestSetup()
-        parent = setup.comments[0]
-        parent.seen = False
-        parent.save()
-        for comment in setup.comments[1:]:
-            comment.parent = parent
-            comment.seen = False
-            comment.save()
-
-        views.mark_thread_seen(setup.comments[3])
-        for comment in setup.comments:
-            self.assertTrue(comment.seen)
-
-
 class ModelMethodTests(TestCase):
     def setUp(self):
         self.user_generator = dummy_user_generator()

--- a/Comments/views.py
+++ b/Comments/views.py
@@ -159,9 +159,6 @@ def create_comment(form, request):
                                      post_date=timezone.now(),
                                      visibility=visibility)
 
-    if user.is_staff:
-        mark_thread_seen(comment)
-        # TODO avoid race condition by sending a list of comments to be marked as seen with the post_comment request
     if comment.visibility == Comment.PRIVATE:
         comment.seen = True
         comment.save()
@@ -213,28 +210,6 @@ def create_comment(form, request):
         obj.creation_time = timezone.now()
         obj.read = False
         obj.save()
-
-
-def mark_thread_seen(comment):
-    """
-    Marks the thread given comment belongs to as seen.
-    :param comment: comment belonging to the thread that should be marked as seen
-    """
-
-    if comment is None:
-        return
-
-    parent_comment = comment if comment.parent is None else comment.parent
-
-    parent_comment.seen = True
-    parent_comment.save()
-
-    if parent_comment.children is None:
-        return
-
-    for comment in parent_comment.children.all():
-        comment.seen = True
-        comment.save()
 
 
 @require_POST

--- a/Comments/views.py
+++ b/Comments/views.py
@@ -159,7 +159,7 @@ def create_comment(form, request):
                                      post_date=timezone.now(),
                                      visibility=visibility)
 
-    if comment.visibility == Comment.PRIVATE:
+    if comment.author.is_staff or comment.visibility == Comment.PRIVATE:
         comment.seen = True
         comment.save()
 

--- a/Elaboration/models.py
+++ b/Elaboration/models.py
@@ -282,10 +282,7 @@ class Elaboration(models.Model):
     def get_complaints(course):
         result = Elaboration.objects.filter(
             challenge__course=course,
-            comments__parent=None,
-            comments__seen=False,
-        ).exclude(
-            comments__visibility=Comment.PRIVATE
+            comments__seen=False
         ).distinct()
 
         return result


### PR DESCRIPTION
Semantic of the seen flag in Comment model has changed slightly. Parent comments' seen does not imply "thread seen" anymore. Instead every comments' seen only flag indicates if this one comment has been seen. This is now the same for parent comments as it is for replies.

Marking comments/threads seen by a staff generated reply now works by clicking the "Mark seen" button via javascript if user is replying and an according seen-link is found. This avoids a race condition seeing when a staff member and a stud write replies at the same time. Would even be nicer to send the data, which comments have to be marked as seen in conjunction with the reply form. But don't know yet how to do this nicely and clicking the button (and therefore generating a second request) seems clean enough.

Adds comment generator for testing.