### PR TITLE
Change notification model

### DIFF
--- a/Notification/migrations/0004_notifications_text.py
+++ b/Notification/migrations/0004_notifications_text.py
@@ -1,0 +1,15 @@
+import os
+from django.db import migrations, models
+
+from AuroraProject.settings import STATIC_URL
+
+
+class Migration(migrations.Migration):
+    dependencies = [("AuroraUser", "0003_aurorauser_tags")]
+
+    operations = [
+        migrations.AlterField('notifications', 'text', models.TextField()),
+        migrations.AlterField('notifications', 'image_url',
+                              models.TextField(default=os.path.join(STATIC_URL, 'img', 'info.jpg'))),
+        migrations.AlterField('notifications', 'link', models.TextField(default="")),
+    ]

--- a/Notification/models.py
+++ b/Notification/models.py
@@ -1,5 +1,4 @@
 import os
-
 from django.core.urlresolvers import reverse
 from django.db import models
 
@@ -9,9 +8,9 @@ from AuroraProject.settings import STATIC_URL
 class Notification(models.Model):
     user = models.ForeignKey('AuroraUser.AuroraUser')
     course = models.ForeignKey('Course.Course')
-    text = models.CharField(max_length=100)
-    image_url = models.CharField(max_length=100, default=os.path.join(STATIC_URL, 'img', 'info.jpg'))
-    link = models.CharField(max_length=100, default="")
+    text = models.TextField()
+    image_url = models.TextField(default=os.path.join(STATIC_URL, 'img', 'info.jpg'))
+    link = models.TextField(default="")
     creation_time = models.DateTimeField(auto_now_add=True)
     read = models.BooleanField(default=False)
 
@@ -37,7 +36,8 @@ class Notification(models.Model):
     def enough_peer_reviews(review):
         final_challenge = review.elaboration.challenge.get_final_challenge()
         stack = final_challenge.get_stack()
-        if stack.has_enough_peer_reviews(review.elaboration.user) and not final_challenge.get_elaboration(review.elaboration.user):
+        if stack.has_enough_peer_reviews(review.elaboration.user) and not final_challenge.get_elaboration(
+                review.elaboration.user):
             text = Notification.truncate_text(Notification.ENOUGH_PEER_REVIEWS + final_challenge.title)
             course = review.elaboration.challenge.get_course()
             obj, created = Notification.objects.get_or_create(


### PR DESCRIPTION
**Caution DO NOT MERGE without testing**
This PR changes a model. It therefore needs to run migration on an already existing database.
So do not merge until this is tested on nova!

This PR only changes the database model. @peterpur if you want longer notifications we need to think of how to display them