### PR TITLE
fix: notification link in author details

### DIFF
--- a/Comments/templates/Comments/comment.html
+++ b/Comments/templates/Comments/comment.html
@@ -1,4 +1,5 @@
 {% load humanize %}
+{% load notification %}
 
 <div class="comment{% if comment.author.is_staff %} staff_author{% endif %} {{ comment.visibility }}_visibility {% if comment.author == requester %} author_author{% endif %} {% if comment.score < 3 %}not3{% endif %}"
 	 data-date="{{ comment.post_date|date:'U' }}"
@@ -41,9 +42,7 @@
 		 {% if requester.is_staff %}
        {{comment.author.matriculation_number}} - {{comment.author.first_name}} {{comment.author.last_name}}<br>
 		   <a href="mailto:{{comment.author.email}}">{{comment.author.email}}</a> &mdash; 
-       {% with notification_user_id=comment.author.id %}
-	         {% include "send_notification_button.html" %}
-       {% endwith %}
+       {% send_notification_button course.short_title comment.author.id%}
        {% if not comment.author.is_staff %}
          {% if course %}
            &mdash;   <a href="{% url 'Evaluation:search_user' course.short_title %}?id={{comment.author.id}}">{{comment.author.display_name}}'s work</a>

--- a/Comments/templates/Comments/response.html
+++ b/Comments/templates/Comments/response.html
@@ -1,4 +1,5 @@
 {% load humanize %}
+{% load notification %}
 
 <div class="response{% if response.author.is_staff %} staff_author{% endif %} {{ response.visibility }}_visibility {% if response.author == requester %} author_author{% endif %} comment_{{comment.id}} {% if response.score < 0 %}neg0{% endif %} {% if response.score < 3 %}not3{% endif %} {% if response.seen and requester.is_staff %}hided{% endif %}"
 	 data-Cdate="{{ comment.post_date|date:'U' }}"
@@ -42,9 +43,7 @@
 		 {% if requester.is_staff %}
        {{response.author.matriculation_number}} - {{response.author.first_name}} {{response.author.last_name}}<br>
 		   <a href="mailto:{{response.author.email}}">{{response.author.email}}</a> &mdash;
-       {% with notification_user_id=response.author.id %}
-         {% include "send_notification_button.html" %}
-       {% endwith %}
+       {% send_notification_button course.short_title response.author.id%}
        {% if not response.author.is_staff %}
          {% if course %}
            &mdash;   <a href="{% url 'Evaluation:search_user' course.short_title %}?id={{response.author.id}}">{{response.author.display_name}}'s work</a>

--- a/Notification/templates/send_notification_button.html
+++ b/Notification/templates/send_notification_button.html
@@ -1,3 +1,13 @@
-<i class="fa fa-external-link"></i> <a href="#" onClick="window.open('/{{ course_short_title }}/notifications/write?user={{ notification_user_id }}','notification','resizable,height=240,width=480'); return false;" class="notification_link" title="send a notification to this user">Send Notification</a>
+<i class="fa fa-external-link"></i>
 
+{% url "Notification:write" course_short_title as notify_url %}
 
+<a href='{{ notify_url }}?user={{ notification_user_id }}'
+   onClick="window.open(
+       '{{ notify_url }}?user={{ notification_user_id }}',
+       'notification', 'resizable,height=240,width=480'
+       );
+       return false;"
+   class="notification_link" title="send a notification to this user">
+  Send Notification
+</a>

--- a/Notification/templatetags/notification.py
+++ b/Notification/templatetags/notification.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag('send_notification_button.html')
+def send_notification_button(course_short_title, user_id):
+    return {
+        'course_short_title': course_short_title,
+        'notification_user_id': user_id,
+    }


### PR DESCRIPTION
There seems to be a bug in the `url` templatetag. I was not able to use
a variable as parameter, that was handed over via `include` templatetag
from another template. Therefore the `send_notification_button`
inclusion tag was created which works.